### PR TITLE
fix: require auth middleware on 2FA settings routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -40,7 +40,7 @@ AdminHelper::registerRoutes(function (): void {
             });
         });
 
-        Route::group(['permission' => 'two-factor-authentication.settings'], function (): void {
+        Route::group(['middleware' => 'auth', 'permission' => 'two-factor-authentication.settings'], function (): void {
             Route::get('settings', [TwoFactorAuthenticationSettingController::class, 'edit'])->name('settings');
             Route::put('settings', [TwoFactorAuthenticationSettingController::class, 'update'])->name(
                 'settings.update'


### PR DESCRIPTION
Fixes #15

The 2FA settings routes were only protected by a permission check, 
with no auth middleware. This allowed unauthenticated users to 
access and modify the settings directly.

Added `auth` to the middleware array on the settings route group 
so unauthenticated requests are redirected to login first.